### PR TITLE
Use more specific error in main()

### DIFF
--- a/YouTubeSpammerPurge.py
+++ b/YouTubeSpammerPurge.py
@@ -42,6 +42,7 @@ from datetime import datetime
 import traceback
 
 from googleapiclient.errors import HttpError
+from googleapiclient.errors import Error as GoogleError
 from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.oauth2.credentials import Credentials
@@ -582,12 +583,12 @@ def main():
   # Authenticate with the Google API - If token expired and invalid, deletes and re-authenticates
   try:
     youtube = get_authenticated_service() # Set easier name for API function
-  except Exception as e:
+  except GoogleError as e:
     if "invalid_grant" in str(e):
       print("Invalid token - Requires Re-Authentication")
       os.remove(TOKEN_FILE_NAME)
       youtube = get_authenticated_service()
-    else:
+  except Exception as e:
       traceback.print_exc() # Prints traceback
       print("----------------")
       print("\nError: " + str(e))

--- a/YouTubeSpammerPurge.py
+++ b/YouTubeSpammerPurge.py
@@ -589,11 +589,11 @@ def main():
       os.remove(TOKEN_FILE_NAME)
       youtube = get_authenticated_service()
   except Exception as e:
-      traceback.print_exc() # Prints traceback
-      print("----------------")
-      print("\nError: " + str(e))
-      input("\nSomething went wrong during authentication. Try deleting token.pickle file. Press Enter to exit...")
-      exit()
+    traceback.print_exc() # Prints traceback
+    print("----------------")
+    print("\nError: " + str(e))
+    input("\nSomething went wrong during authentication. Try deleting token.pickle file. Press Enter to exit...")
+    exit()
   
   # Intro message
   print("\n============ YOUTUBE SPAMMER PURGE v" + version + " ============")


### PR DESCRIPTION
using googleapiclient.errors.Error for exception handling in main() rather than Exception to avoid catching unintended system exceptions (KeyboardInterrupt, OutOfMemoryError, FileNotFoundError etc.). The "Exception as e" part now only exists for smooth exiting, and won't be compared in the `if` block.