### PR TITLE
Update script so that it doesn't throw an error when trying to clear on Linux or Unix-based systems.

### DIFF
--- a/YouTubeSpammerPurge.py
+++ b/YouTubeSpammerPurge.py
@@ -43,6 +43,7 @@ import os
 import re
 from datetime import datetime
 import traceback
+import platform
 
 from googleapiclient.errors import HttpError
 from googleapiclient.discovery import build
@@ -871,7 +872,10 @@ def main():
   logMode = False
 
   # Initiates colorama and creates shorthand variables for resetting colors
-  os.system('cls')
+  if platform.system() == "Windows":
+    os.system("cls")
+  else:
+    os.system("clear")
   init(autoreset=True)
   S.R = S.RESET_ALL
   F.R = F.RESET

--- a/YouTubeSpammerPurge.py
+++ b/YouTubeSpammerPurge.py
@@ -52,6 +52,8 @@ from google.oauth2.credentials import Credentials
 from google.auth.transport.requests import Request
 from colorama import init, Fore as F, Back as B, Style as S
 
+clear_command = "cls" if platform.system() == "Windows" else "clear"
+
 ##########################################################################################
 ################################## AUTHORIZATION #########################################
 ##########################################################################################
@@ -872,10 +874,7 @@ def main():
   logMode = False
 
   # Initiates colorama and creates shorthand variables for resetting colors
-  if platform.system() == "Windows":
-    os.system("cls")
-  else:
-    os.system("clear")
+  os.system(clear_command)
   init(autoreset=True)
   S.R = S.RESET_ALL
   F.R = F.RESET


### PR DESCRIPTION
The original script would crash if run on a Linux or Unix machine. This happens because the clear command for Windows systems and Linux/Unix-based systems are different. So, I changed the script to check if it is being run on a Windows machine. If so, it will clear the command prompt using the `cls` command. If it is not being run on a Windows machine, it will clear the terminal using the `clear` command.